### PR TITLE
Fixed file_candump_test on windows

### DIFF
--- a/pyvit/file/db/jsondb.py
+++ b/pyvit/file/db/jsondb.py
@@ -1,5 +1,5 @@
 import json
-from .. import bus
+from pyvit import bus
 
 
 class JsonDbParser():
@@ -22,7 +22,7 @@ class JsonDbParser():
                     if 'offset' in sig:
                         s.offset = int(sig['offset'])
                     if 'factor' in sig:
-                        s.factor = int(sig['factor'])
+                        s.factor = float(sig['factor'])
 
                     # add this signal to the message
                     m.add_signal(s, int(start_bit))

--- a/test/file_candump_test.py
+++ b/test/file_candump_test.py
@@ -1,3 +1,5 @@
+import tempfile
+
 import pyvit.can as can
 from pyvit.file import log
 
@@ -6,8 +8,10 @@ import unittest
 class FileCanDumpTest(unittest.TestCase):
     def test_defaults(self):
         """ Test write & readback of candump file with default timestamp and interface """
-        
-        cdf = log.CandumpFile('/tmp/testfile1')
+        temp_file = tempfile.NamedTemporaryFile(delete=False)
+        file_name = temp_file.name
+
+        cdf = log.CandumpFile(file_name)
 
         frames = [can.Frame(0x123, [1,2,3,4,5,6,7,8]),
                 can.Frame(0x0),
@@ -16,12 +20,17 @@ class FileCanDumpTest(unittest.TestCase):
         cdf.export_frames(frames)
         frames2 = cdf.import_frames()
 
+        temp_file.close()
+
         for i in range(0, len(frames)):
             self.assertEqual(frames[i], frames2[i])
 
     def test_full(self):
         """ Test write & readback of candump file with defined timestamp and interface """
-        cdf = log.CandumpFile('/tmp/testfile1')
+        temp_file = tempfile.NamedTemporaryFile(delete=False)
+        file_name = temp_file.name
+
+        cdf = log.CandumpFile(file_name)
 
         frames = [can.Frame(0x1,
                             [1,2,3,4,5,6,7,8],
@@ -37,6 +46,8 @@ class FileCanDumpTest(unittest.TestCase):
 
         cdf.export_frames(frames)
         frames2 = cdf.import_frames()
+
+        temp_file.close()
 
         for i in range(0, len(frames)):
             self.assertEqual(frames[i], frames2[i])

--- a/test/json_db_test.py
+++ b/test/json_db_test.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import pyvit.can as can
+from pyvit.file.db.jsondb import JsonDbParser
+
+import unittest
+
+
+class FileDbJsonDbTest(unittest.TestCase):
+    def test_defaults(self):
+        """ Test parsing a json database """
+        uut = JsonDbParser()
+
+        """ Should not throw any exceptions or errors """
+        file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'vector_jsondb.json')
+        bus_db = uut.parse(file_path)
+
+        """ [600 RPM, 4th gear, 2 units of voltage, unit to be divided by 10, unit with offset] """
+        frame_1 = can.Frame(0x123, [88, 2, 0b00010100, 50, 10])
+
+        signals = bus_db.parse_frame(frame_1)
+        """ Need help asserting equality for signal values. """
+        """ The order seems to change (array) """
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/json_db_test.py
+++ b/test/json_db_test.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import pyvit.can as can
 from pyvit.file.db.jsondb import JsonDbParser
 
@@ -11,16 +10,16 @@ class FileDbJsonDbTest(unittest.TestCase):
         """ Test parsing a json database """
         uut = JsonDbParser()
 
-        """ Should not throw any exceptions or errors """
+        # Should not throw any exceptions or errors
         file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'vector_jsondb.json')
         bus_db = uut.parse(file_path)
 
-        """ [600 RPM, 4th gear, 2 units of voltage, unit to be divided by 10, unit with offset] """
+        # [600 RPM, 4th gear, 2 units of voltage, unit to be divided by 10, unit with offset]
         frame_1 = can.Frame(0x123, [88, 2, 0b00010100, 50, 10])
 
         signals = bus_db.parse_frame(frame_1)
-        """ Need help asserting equality for signal values. """
-        """ The order seems to change (array) """
+        # Need help asserting equality for signal values.
+        # The order seems to change (array)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/vector_jsondb.json
+++ b/test/vector_jsondb.json
@@ -1,0 +1,34 @@
+{
+  "messages": [
+    {
+      "name": "test vector msg",
+      "id": "0x123",
+      "signals": {
+        "0": {
+          "name": "Engine RPM",
+          "bit_length": 16,
+          "factor": 1,
+          "offset": 0
+        },
+        "16": {
+          "name": "Gear",
+          "bit_length": 3
+        },
+        "19": {
+          "name": "Battery Voltage",
+          "bit_length": 5
+        },
+        "24": {
+          "name": "Fractional Factor",
+          "bit_length": 8,
+          "factor": 0.1
+        },
+        "32": {
+          "name": "Negative offset",
+          "bit_length": 8,
+          "offset": -100
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Just grabs a temp file instead of relying on the UNIX filesystem.

Additionally, adds support for factors <1.0 in message database files
with included tests.

Fixes #13 