### PR TITLE
Bug fix: frame returning 0 for ext_id = True

### DIFF
--- a/pyvit/hw/cantact.py
+++ b/pyvit/hw/cantact.py
@@ -76,7 +76,7 @@ class CantactDev:
         # parse the data bytes
         data = []
         for i in range(0, dlc):
-            data.append(int(rx_str[data_offset+i*2:7+i*2], 16))
+            data.append(int(rx_str[data_offset+i*2:(data_offset+2)+i*2], 16))
             frame.data = data
 
         return frame


### PR DESCRIPTION
Bug: frame.data was returning 0 for frames with ext_id=True. 
Fix: Changed range to (data_offset+2) instead of hard-coded 7.