### PR TITLE
Support extended IDs in `CantactDev.recv()`

### DIFF
--- a/pyvit/hw/cantact.py
+++ b/pyvit/hw/cantact.py
@@ -69,7 +69,7 @@ class CantactDev:
             data_offset = 5
 
         # create the frame
-        frame = can.Frame(arb_id)
+        frame = can.Frame(arb_id, extended=ext_id)
         if remote:
             frame.frame_type = can.FrameType.RemoteFrame
 


### PR DESCRIPTION
`CantactDev.recv()` was creating the `can.Frame` without specifying whether it had an extended arbitration ID or not. The default is `False`, and so the extended ID was throwing `ValueError: Arbitration ID out of range`.

Signed-off-by: Scott Armitage <scott@armitage.space>