### PR TITLE
Recreate TX queue on dispatcher (re-)start

### DIFF
--- a/pyvit/dispatch.py
+++ b/pyvit/dispatch.py
@@ -42,6 +42,7 @@ class Dispatcher:
             raise Exception('dispatcher already running')
 
         self._device.start()
+        self._tx_queue = Queue()
 
         self._send_process = Process(target=self._send_loop)
         self._recv_process = Process(target=self._recv_loop)


### PR DESCRIPTION
Recreate TX queue in the `Dispacher.start()` method to avoid strange blocking (apparently due to some race condition, didn't manage to find for sure) while sending data from the queue after the dispatcher restart cycle (i.e. `start()` - `stop()` - `start()` sequence on the same dispatcher object).

Signed-off-by: Alexey Chernov <4ernov@gmail.com>