### PR TITLE
When used on a busy can bus on Linux/socketcan we had overruns as soo…

### DIFF
--- a/pyvit/dispatch.py
+++ b/pyvit/dispatch.py
@@ -78,6 +78,16 @@ class Dispatcher:
         self._device.stop()
         self._running = False
 
+        #
+        # Clear any data from current queues
+        #
+        for q in self._rx_queues:
+            while not q.empty():
+                q.get()
+        while not self._tx_queue.empty():
+                q.get()
+
+
     @property
     def is_running(self):
         return self._running

--- a/pyvit/dispatch.py
+++ b/pyvit/dispatch.py
@@ -26,6 +26,22 @@ class Dispatcher:
         self._running = False
         self._single_process = single_process
 
+        #
+        # Will only operate on filters if the underlying can hardware supports 
+        # filtering.
+        #
+        if hasattr(device, 'apply_filters'):
+            self._filter_list = []
+        else:
+            self._filter_list = None
+
+    def add_filter(self, id, mask):
+        if self._filter_list != None:
+            self._filter_list.append((id,mask))
+
+        if self._device.running:
+            self._device.apply_filters(self._filter_list)
+
     def add_receiver(self, rx_queue):
         if self.is_running:
             raise Exception('dispatcher must be stopped to add receiver')
@@ -52,6 +68,9 @@ class Dispatcher:
     def start(self):
         if self.is_running:
             raise Exception('dispatcher already running')
+
+        if self._filter_list:
+            self._device.apply_filters(self._filter_list)
 
         self._device.start()
         self._tx_queue = Queue()

--- a/pyvit/hw/socketcan.py
+++ b/pyvit/hw/socketcan.py
@@ -6,6 +6,7 @@ from .. import can
 
 
 class SocketCanDev:
+
     def __init__(self, ndev):
         self.running = False
 
@@ -24,6 +25,23 @@ class SocketCanDev:
 
     def stop(self):
         pass
+
+    def apply_filters(self, filter_list):
+        #
+        # The can_filter struct looks like
+        # struct can_filter{
+        #       uint32_t id;
+        #       uint32_t mask;
+        # };
+        # the *optval is an array of the above structures.  The size of the array 
+        # cannot exceed 512 entries.
+        #
+        encodedArray = b""
+        for (fid, mask) in filter_list:
+            entry = struct.pack('<LL', fid, mask)
+            encodedArray += entry
+
+        self.socket.setsockopt(socket.SOL_CAN_RAW, socket.CAN_RAW_FILTER, encodedArray)
 
     def recv(self):
         assert self.running, 'device not running'

--- a/pyvit/proto/uds.py
+++ b/pyvit/proto/uds.py
@@ -1448,6 +1448,8 @@ class UDSInterface:
             self.transport_layer = IsotpNormalAddressing(dispatcher, tx_arb_id)
             self.transport_layer.rx_arb_id = rx_arb_id
 
+        dispatcher.add_filter(id=rx_arb_id, mask=0x7ff)
+
     def request(self, service, timeout=0.5):
         self.transport_layer.send(service.encode())
         if self.transport_layer.N_TAtype == N_TAtype.physical:


### PR DESCRIPTION
Signed-off-by: Miller Lowe <milhead@gmail.com>

UDS interface was loosing packets on a 500kbps bus running around 50%, socketcan allows filtering so that the application will only see the UDS receive ID.  This change will automatically utilize filtering if a UDS Interface is created.

Note that if the dispatcher is going to receive messages other than the UDS receive ID they will need filters added.  The filter in only created automatically if you hand the dispatcher to the UDS interface constructor.

This commit enables the use of socketcan filtering when used as a UDS device.

overall commands Sent        : 6000
overall average response time: 0.0048991614580154415
overall standard deviation   : 0.002319849086112244
overall max delay            : 0.05056476593017578
overall min delay            : 0.0018734931945800781